### PR TITLE
Make some improvements to the slack-app feature

### DIFF
--- a/version_check/core.py
+++ b/version_check/core.py
@@ -86,6 +86,9 @@ def get_branch_matches(commit, limiters=None):
         if line.startswith('remotes/'):
             # strip off remotes/REMOTE/
             line = line[strip_len:]
+            # handle other possible remotes - don't include them
+            if '/' in line:
+                continue
             if line.startswith('HEAD'):
                 continue
             branches.append(line)


### PR DESCRIPTION
- Use Slack's signing secret instead of verification tokens
- Only search branches on the configured remote
- Allow commits to be searched for as well as PR numbers