### PR TITLE
Fix docker build error (No module named version_check)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get -y install git python3-pip
 
 RUN git clone https://github.com/saltstack/salt.git
 
-COPY version_check/ /
+COPY . /version_check
+RUN pip3 install ./version_check
 
-ENTRYPOINT ["python3", "cli.py"]
-
+ENTRYPOINT ["version-check"]


### PR DESCRIPTION
Fix the `ModuleNotFoundError: No module named 'version_check'` error when running `docker build -t version_check `.